### PR TITLE
finishing onboarding screen ✅

### DIFF
--- a/lib/bubble_up.dart
+++ b/lib/bubble_up.dart
@@ -1,5 +1,5 @@
 import 'package:chatting_app/core/routing/app_router.dart';
-import 'package:chatting_app/core/routing/router_constants.dart';
+import 'package:chatting_app/core/routing/app_routes.dart';
 import 'package:chatting_app/features/onboarding/ui/screens/onboarding_screen.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -14,9 +14,8 @@ class BubbleUp extends StatelessWidget {
       minTextAdapt: true,
       child: MaterialApp(
         debugShowCheckedModeBanner: false,
-        initialRoute: RouterConstants.onboarding,
-        onGenerateRoute: AppRouter().generateRoute,
-        home: OnboardingScreen(),
+        initialRoute: AppRoutes.onboarding,
+        onGenerateRoute: AppRouter(context).generateRoute,
       ),
     );
   }

--- a/lib/core/routing/app_router.dart
+++ b/lib/core/routing/app_router.dart
@@ -1,14 +1,26 @@
-import 'package:chatting_app/core/routing/router_constants.dart';
+import 'package:chatting_app/core/routing/app_routes.dart';
+import 'package:chatting_app/features/auth/ui/screens/login_screen.dart';
+import 'package:chatting_app/features/onboarding/logic/onboarding_provider.dart';
 import 'package:chatting_app/features/onboarding/ui/screens/onboarding_screen.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
 
-class AppRouter { 
-  Route? generateRoute(RouteSettings settings) { 
-    switch(settings.name) { 
-      case RouterConstants.onboarding: 
-        return MaterialPageRoute(builder: (_) => OnboardingScreen());
-
+class AppRouter {
+  BuildContext context;
+  AppRouter(this.context);
+  Route? generateRoute(RouteSettings settings) {
+    switch (settings.name) {
+      case AppRoutes.onboarding:
+        return MaterialPageRoute(
+          builder:
+              (_) => ChangeNotifierProvider<OnboardingProvider>(
+                create: (_) => OnboardingProvider(),
+                child: OnboardingScreen(),
+              ),
+        );
+      case AppRoutes.login:
+        return MaterialPageRoute(builder: (_) => LoginScreen());
     }
   }
 }

--- a/lib/core/routing/app_routes.dart
+++ b/lib/core/routing/app_routes.dart
@@ -1,0 +1,4 @@
+class AppRoutes {
+  static const String onboarding = '/onboarding';
+  static const String login = '/login';
+}

--- a/lib/core/routing/router_constants.dart
+++ b/lib/core/routing/router_constants.dart
@@ -1,3 +1,0 @@
-class   RouterConstants {
-  static const String onboarding = '/onboarding';
-}

--- a/lib/core/theming/app_colors.dart
+++ b/lib/core/theming/app_colors.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 
 class AppColors {
-  static const Color darkBlue = Color(0xff);
+  static const Color darkBlue = Color(0xff120263);
+  static const Color blue = Color(0xff0A74EE);
 }

--- a/lib/core/theming/app_text_styles.dart
+++ b/lib/core/theming/app_text_styles.dart
@@ -1,3 +1,4 @@
+import 'package:chatting_app/core/theming/app_colors.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -6,11 +7,18 @@ class AppTextStyles {
   static TextStyle font20DarkBlueBold = TextStyle(
     fontSize: 20.sp,
     fontWeight: FontWeight.bold,
+    color: AppColors.darkBlue,
   );
 
   static TextStyle font12GreyRegular = TextStyle(
     fontSize: 12.sp,
     fontWeight: FontWeight.w400,
     color: Colors.grey,
+  );
+
+  static TextStyle font14WhiteBold =  TextStyle(
+    fontSize: 14.sp,
+    fontWeight: FontWeight.bold,
+    color: Colors.white,
   );
 }

--- a/lib/features/auth/ui/screens/login_screen.dart
+++ b/lib/features/auth/ui/screens/login_screen.dart
@@ -1,0 +1,22 @@
+import 'package:chatting_app/core/theming/app_text_styles.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+
+class LoginScreen extends StatelessWidget {
+  const LoginScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Column(
+        children: [
+          Container(
+            width: double.infinity,
+            height: 500.h,
+            decoration: BoxDecoration(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/logic/onboarding_provider.dart
+++ b/lib/features/onboarding/logic/onboarding_provider.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:chatting_app/core/routing/app_routes.dart';
+import 'package:chatting_app/core/statics/statics.dart';
+import 'package:flutter/material.dart';
+
+class OnboardingProvider extends ChangeNotifier {
+  int _currentPage = 0;
+  int get currentPage => _currentPage;
+
+  final PageController _controller = PageController();
+  PageController get controller => _controller;
+  void chagePage(int index) {
+    _currentPage = index;
+    notifyListeners();
+  }
+
+  void changePageOnGetStartedButtonClick(BuildContext context) {
+    _currentPage++;
+    notifyListeners();
+    if (currentPage > onBoardingPages.length - 1) {
+      _currentPage = onBoardingPages.length - 1;
+      try {
+        Navigator.pushReplacementNamed(context, AppRoutes.login);
+      } catch (e) {
+        print(e);
+      }
+      return;
+    } else {
+      _controller.animateToPage(
+        currentPage,
+        duration: Duration(seconds: 1),
+        curve: Curves.easeIn,
+      );
+    }
+  }
+}

--- a/lib/features/onboarding/ui/screens/onboarding_screen.dart
+++ b/lib/features/onboarding/ui/screens/onboarding_screen.dart
@@ -1,7 +1,10 @@
-
+import 'package:chatting_app/core/statics/statics.dart';
+import 'package:chatting_app/core/theming/app_colors.dart';
+import 'package:chatting_app/features/onboarding/ui/widgets/app_get_started_button.dart';
+import 'package:chatting_app/features/onboarding/ui/widgets/current_page_dots_indicator.dart';
 import 'package:chatting_app/features/onboarding/ui/widgets/onboarding_page_scroll.dart';
 import 'package:flutter/material.dart';
-
+import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 class OnboardingScreen extends StatelessWidget {
   const OnboardingScreen({super.key});
@@ -14,6 +17,13 @@ class OnboardingScreen extends StatelessWidget {
         child: Column(
           children: [
             OnBoardingPageScroll(),
+            CurrentPageDotsIndicator(
+              dotsLength: onBoardingPages.length,
+              activeDotColor: AppColors.blue,
+              inactiveDotsColor: Colors.grey,
+            ),
+            SizedBox(height: 16.h),
+            AppGetStartedButton(),
           ],
         ),
       ),

--- a/lib/features/onboarding/ui/widgets/app_get_started_button.dart
+++ b/lib/features/onboarding/ui/widgets/app_get_started_button.dart
@@ -1,0 +1,34 @@
+import 'package:chatting_app/core/theming/app_colors.dart';
+import 'package:chatting_app/core/theming/app_text_styles.dart';
+import 'package:chatting_app/features/onboarding/logic/onboarding_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:provider/provider.dart';
+
+class AppGetStartedButton extends StatelessWidget {
+  const AppGetStartedButton({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return TextButton(
+      style: ButtonStyle(
+        backgroundColor: WidgetStatePropertyAll<Color>(AppColors.blue),
+        shape: WidgetStatePropertyAll<OutlinedBorder>(
+          RoundedRectangleBorder(borderRadius: BorderRadius.circular(16.r)),
+        ),
+        padding: WidgetStatePropertyAll<EdgeInsetsGeometry>(
+          EdgeInsets.symmetric(horizontal: 30.w, vertical: 10.h),
+        ),
+      ),
+      onPressed: () {
+        context.read<OnboardingProvider>().changePageOnGetStartedButtonClick(context);
+      },
+      child: Text(
+        context.watch<OnboardingProvider>().currentPage == 0
+            ? "Next"
+            : "Start Now",
+        style: AppTextStyles.font14WhiteBold,
+      ),
+    );
+  }
+}

--- a/lib/features/onboarding/ui/widgets/current_page_dots_indicator.dart
+++ b/lib/features/onboarding/ui/widgets/current_page_dots_indicator.dart
@@ -1,0 +1,43 @@
+import 'package:chatting_app/core/statics/statics.dart';
+import 'package:chatting_app/core/theming/app_colors.dart';
+import 'package:chatting_app/features/onboarding/logic/onboarding_provider.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:provider/provider.dart';
+
+class CurrentPageDotsIndicator extends StatelessWidget {
+  int dotsLength;
+  Color activeDotColor;
+  Color inactiveDotsColor;
+  CurrentPageDotsIndicator({
+    super.key,
+    required this.dotsLength,
+    required this.activeDotColor,
+    required this.inactiveDotsColor,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Wrap(
+      children: List.generate(dotsLength, (index) {
+        return AnimatedContainer(
+          duration: Duration(milliseconds: 500),
+          curve: Curves.easeOut,
+          width:
+              index == context.watch<OnboardingProvider>().currentPage
+                  ? 20.w
+                  : 10.w,
+          height: 10.h,
+          margin: EdgeInsets.only(left: 10.w),
+          decoration: BoxDecoration(
+            color:
+                index == context.watch<OnboardingProvider>().currentPage
+                    ? activeDotColor
+                    : inactiveDotsColor,
+            borderRadius: BorderRadius.circular(15.r),
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/lib/features/onboarding/ui/widgets/onboarding_page_scroll.dart
+++ b/lib/features/onboarding/ui/widgets/onboarding_page_scroll.dart
@@ -1,18 +1,22 @@
 import 'package:chatting_app/core/statics/statics.dart';
-import 'package:chatting_app/core/theming/app_text_styles.dart';
-import 'package:chatting_app/features/onboarding/data/onboarding_page_model.dart';
+import 'package:chatting_app/features/onboarding/logic/onboarding_provider.dart';
 import 'package:chatting_app/features/onboarding/ui/widgets/onboarding_page.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:provider/provider.dart';
 
 class OnBoardingPageScroll extends StatelessWidget {
-  const OnBoardingPageScroll({super.key});
+  OnBoardingPageScroll({super.key});
 
   @override
   Widget build(BuildContext context) {
     return SizedBox(
       height: 500.h,
       child: PageView.builder(
+        controller: context.read<OnboardingProvider>().controller,
+        onPageChanged: (index) {
+          context.read<OnboardingProvider>().chagePage(index);
+        },
         itemCount: onBoardingPages.length,
         itemBuilder: (context, index) {
           return OnBoardingPage(pageInfo: onBoardingPages[index]);

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -139,6 +139,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0"
   path:
     dependency: transitive
     description:
@@ -147,6 +155,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  provider:
+    dependency: "direct main"
+    description:
+      name: provider
+      sha256: "4abbd070a04e9ddc287673bf5a030c7ca8b685ff70218720abab8b092f53dd84"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.5"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_screenutil: ^5.9.3
+  provider: ^6.1.5
 
 dev_dependencies:
   flutter_lints: ^5.0.0


### PR DESCRIPTION
- added Dots indecator
- handle onboarding change page logic
- added onboarding provider to handle on boarding state management
- changing `AppConstants` to => `AppRoutes` for better naming convention

-onboarding final preview screen one : 
![Screenshot_1750253437](https://github.com/user-attachments/assets/422b480f-667f-4e8a-b8f8-c6c04c7a405d)



-onboarding final preview screen two: 
![Screenshot_1750253442](https://github.com/user-attachments/assets/5e649021-26c5-45f4-ae94-6427744793f5)

